### PR TITLE
Remove runner boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ For GithubAction, you need to set GITHUB_TOKEN as environment [example](https://
 1. Adding `--debug` flag to any command you want to run.
 2. Waiting for text `Observatory listening on http://127.0.0.1:8181/xxxxxxx=/ `
 3. Attach process on your editor.
-   - For `VSCode`, go to `View > Command Palette` and choose `>Debug: Attach to Dart Process`, and put `http://127.0.0.1:8181/xxxxxxx=/`.
+   - For `VSCode`, you need to open `dangerfile.dart` in new window, go to `View > Command Palette` and choose `>Debug: Attach to Dart Process`, and put `http://127.0.0.1:8181/xxxxxxx=/`.
    - For `AndroidStudio` and `Intellij` .....
-4. Debugger will start with pausing at `danger_dart.dart`, you can skip it, after that it will stop at your `dangerfile`
+4. Debugger will start with pausing at `dangerfile.g.dart`, you can skip it, but don't forget to set breakpoint in your `dangerfile.dart`
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ dev_dependencies:
 // @dart=2.10
 import 'package:danger_core/danger_core.dart';
 
-void main(List<String> args, dynamic data) {
-  Danger.setup(data);
-
+void main() {
   if (danger.github.pr.title.contains('WIP')) {
     warn('PR is considered WIP');
   }

--- a/dangerfile.dart
+++ b/dangerfile.dart
@@ -5,9 +5,7 @@ import 'package:path/path.dart' show join, current;
 import 'package:danger_core/danger_core.dart';
 import 'package:danger_plugin_dart_test/danger_plugin_dart_test.dart';
 
-void main(List<String> args, dynamic data) {
-  Danger.setup(data);
-
+void main() {
   if (danger.github == null) {
     message('Welcome to danger local');
   }

--- a/example/pre_nullsafety/dangerfile.dart
+++ b/example/pre_nullsafety/dangerfile.dart
@@ -1,8 +1,6 @@
 // @dart=2.10
 import 'package:danger_core/danger_core.dart';
 
-void main(List<String> args, dynamic data) {
-  Danger.setup(data);
-
+void main() {
   message('hello from pre-nullsafety');
 }

--- a/example/target_nullsafety/dangerfile.dart
+++ b/example/target_nullsafety/dangerfile.dart
@@ -1,8 +1,6 @@
 // @dart=2.10
 import 'package:danger_core/danger_core.dart';
 
-void main(List<String> args, dynamic data) {
-  Danger.setup(data);
-
+void main() {
   message('hello from nullsafety');
 }

--- a/example/with_plugin/dangerfile.dart
+++ b/example/with_plugin/dangerfile.dart
@@ -2,9 +2,7 @@
 import 'package:danger_core/danger_core.dart';
 import 'package:danger_plugin_example/danger_plugin_example.dart';
 
-
-void main(List<String> args, dynamic data) {
-  Danger.setup(data);
+void main() {
   dangerRandomGenerateCode();
 
   message('Hello World');

--- a/packages/danger_dart/lib/commands/base/danger_wrapper_command.dart
+++ b/packages/danger_dart/lib/commands/base/danger_wrapper_command.dart
@@ -49,14 +49,18 @@ abstract class DangerWrapperCommand extends Command {
       ...isDebug
           ? [
               '--observe=8181',
-              '--pause-isolates-on-start',
-              '--no-pause-isolates-on-exit'
+              '--no-pause-isolates-on-exit',
             ]
           : [],
       '${dangerUtil.getScriptFilePath()}',
       'process',
       '--dangerfile',
       dangerFilePath,
+      ...isDebug
+          ? [
+              '--debug'
+            ]
+          : [],
     ].join(' ');
 
     final dangerJSCommand = <String>[

--- a/packages/danger_dart/lib/commands/local_command.dart
+++ b/packages/danger_dart/lib/commands/local_command.dart
@@ -51,7 +51,6 @@ class LocalCommand extends Command {
       ...isDebug
           ? [
               '--observe=8181',
-              '--pause-isolates-on-start',
               '--no-pause-isolates-on-exit'
             ]
           : [],
@@ -59,6 +58,11 @@ class LocalCommand extends Command {
       'process',
       '--dangerfile',
       dangerFilePath,
+      ...isDebug
+          ? [
+              '--debug'
+            ]
+          : [],
     ].join(' ');
 
     final dangerJSCommand = <String>[

--- a/packages/danger_dart/lib/commands/local_command.dart
+++ b/packages/danger_dart/lib/commands/local_command.dart
@@ -43,26 +43,17 @@ class LocalCommand extends Command {
           DebugTree(useColors: useColors, logLevels: ['I', 'W', 'E']));
     }
 
-    final dangerFilePath = dangerUtil.getScriptFilePath();
+    final dangerFilePath = dangerUtil.getDangerFile(args);
     final metaData = await dangerUtil.getDangerJSMetaData(args);
     final dangerProcessCommand = <String>[
       'dart',
       'run',
-      ...isDebug
-          ? [
-              '--observe=8181',
-              '--no-pause-isolates-on-exit'
-            ]
-          : [],
+      ...isDebug ? ['--observe=8181', '--no-pause-isolates-on-exit'] : [],
       '${dangerUtil.getScriptFilePath()}',
       'process',
       '--dangerfile',
       dangerFilePath,
-      ...isDebug
-          ? [
-              '--debug'
-            ]
-          : [],
+      ...isDebug ? ['--debug'] : [],
     ].join(' ');
 
     final dangerJSCommand = <String>[

--- a/packages/danger_dart/lib/commands/process_command.dart
+++ b/packages/danger_dart/lib/commands/process_command.dart
@@ -21,6 +21,7 @@ class ProcessCommand extends Command {
       'dangerfile',
       help: 'Location of dangerfile',
     );
+    argParser.addFlag('debug', defaultsTo: false, negatable: false);
     argParser.addFlag('verbose', defaultsTo: false, negatable: false);
   }
 
@@ -41,6 +42,7 @@ class ProcessCommand extends Command {
 
     var inputStr = (await _stdin.transform(utf8.decoder).toList()).join('');
 
+    final isDebug = args.wasParsed('debug');
     final isVerbose = args.wasParsed('verbose');
     final useColors = (Platform.environment['TERM'] ?? '').contains('xterm');
     if (isVerbose) {
@@ -91,7 +93,7 @@ class ProcessCommand extends Command {
       isolateReceiver = DangerIsolateReceiver(json);
 
       await _dangerUtil.spawnFile(
-          dangerFile, isolateReceiver.toMessage());
+          dangerFile, isolateReceiver.toMessage(), isDebug);
 
       final resultStr = jsonEncode(isolateReceiver.dangerResults);
       final tempDir = Directory.systemTemp;

--- a/packages/danger_dart/lib/danger_util.dart
+++ b/packages/danger_dart/lib/danger_util.dart
@@ -79,7 +79,7 @@ class DangerUtil {
     return DangerJSMetadata(executable: dangerJSExecutable);
   }
 
-  Future<void> spawnFile(File dangerFile, dynamic message) async {
+  Future<void> spawnFile(File dangerFile, dynamic message, bool isDebug) async {
     final exitPort = ReceivePort();
     final errorPort = ReceivePort();
 
@@ -94,7 +94,7 @@ class DangerUtil {
       isolateErrorCompleter.completeError(message);
     });
 
-    final tempDangerFile = _createTempDangerFile(dangerFile);
+    final tempDangerFile = _createTempDangerFile(dangerFile, isDebug);
 
     final currentIsolate = await Isolate.spawnUri(
         tempDangerFile.uri, [], message,
@@ -114,8 +114,8 @@ class DangerUtil {
     });
   }
 
-  File _createTempDangerFile(File dangerFile) {
-    final tempFilePath = '${dangerFile.path}spawnUri.g.dart';
+  File _createTempDangerFile(File dangerFile, bool isDebug) {
+    final tempFilePath = '${dangerFile.path}.g.dart';
     final tempFile = File(tempFilePath);
     if (tempFile.existsSync()) {
       tempFile.deleteSync();
@@ -123,11 +123,14 @@ class DangerUtil {
     tempFile.createSync();
     tempFile.writeAsStringSync('''
 // @dart=2.7
+import 'dart:developer';
+
 import 'package:danger_core/danger_core.dart';
 import './${dangerFile.path}' as danger_file;
 
 void main(List<String> args, dynamic data) {
   Danger.setup(data);
+${isDebug ? '  debugger();' : ''}
 
   danger_file.main();
 }

--- a/packages/danger_dart/test/commands/local_command_test.dart
+++ b/packages/danger_dart/test/commands/local_command_test.dart
@@ -87,8 +87,9 @@ void main() {
           result.first.toString().split('--process').last.trim();
 
       expect(processCommand, contains('--observe=8181'));
-      expect(processCommand, contains('--pause-isolates-on-start'));
       expect(processCommand, contains('--no-pause-isolates-on-exit'));
+
+      expect(processCommand, contains('--debug'));
     });
   });
 }

--- a/packages/danger_dart/test/commands/pr_command_test.dart
+++ b/packages/danger_dart/test/commands/pr_command_test.dart
@@ -89,8 +89,9 @@ void main() {
           result.first.toString().split('--process').last.trim();
 
       expect(processCommand, contains('--observe=8181'));
-      expect(processCommand, contains('--pause-isolates-on-start'));
       expect(processCommand, contains('--no-pause-isolates-on-exit'));
+      
+      expect(processCommand, contains('--debug'));
     });
   });
 }

--- a/packages/danger_dart/test/commands/process_command_test.dart
+++ b/packages/danger_dart/test/commands/process_command_test.dart
@@ -38,7 +38,7 @@ void main() {
         return DangerJSMetadata(executable: '/usr/local/danger-js');
       });
 
-      when(_mockDangerUtil.spawnFile(captureAny, captureAny))
+      when(_mockDangerUtil.spawnFile(captureAny, captureAny, captureAny))
           .thenAnswer((realInvocation) async {});
 
       when(_mockDangerUtil.getDangerFile(any))
@@ -62,7 +62,7 @@ void main() {
           .run(['process', '--dangerfile', 'bin/danger_dart.dart', '--verbose']);
 
       final result =
-          verify(_mockDangerUtil.spawnFile(captureAny, captureAny)).captured;
+          verify(_mockDangerUtil.spawnFile(captureAny, captureAny, captureAny)).captured;
       final url = result[0];
       expect(url.path.toString(), endsWith('/bin/danger_dart.dart'));
     });
@@ -73,7 +73,7 @@ void main() {
           .run(['process', '--dangerfile', 'bin/danger_dart.dart', '--verbose']);
 
       final result =
-          verify(_mockDangerUtil.spawnFile(captureAny, captureAny)).captured;
+          verify(_mockDangerUtil.spawnFile(captureAny, captureAny,captureAny)).captured;
       final message = result[1];
 
       final sendPort = message[DANGER_SEND_PORT_MESSAGE_KEY];
@@ -85,7 +85,7 @@ void main() {
           .run(['process', '--dangerfile', 'bin/danger_dart.dart', '--verbose']);
 
       final result =
-          verify(_mockDangerUtil.spawnFile(captureAny, captureAny)).captured;
+          verify(_mockDangerUtil.spawnFile(captureAny, captureAny, captureAny)).captured;
       final message = result[1];
 
       final dslJSON = message[DANGER_DSL_MESSAGE_KEY];

--- a/packages/danger_dart/test/commands/process_command_test.dart
+++ b/packages/danger_dart/test/commands/process_command_test.dart
@@ -29,7 +29,8 @@ void main() {
       _mockDangerUtil = _MockDangerUtil();
       _mockStdin = _MockStdin();
       _mockStdout = _MockStdout();
-      _processCommand = ProcessCommand(_mockDangerUtil, _mockStdin, _mockStdout);
+      _processCommand =
+          ProcessCommand(_mockDangerUtil, _mockStdin, _mockStdout);
       _commandRunner = TestCommandRunner.create(_processCommand);
 
       when(_mockDangerUtil.getDangerJSMetaData(any, shell: anyNamed('shell')))
@@ -37,7 +38,7 @@ void main() {
         return DangerJSMetadata(executable: '/usr/local/danger-js');
       });
 
-      when(_mockDangerUtil.spawnUri(captureAny, captureAny))
+      when(_mockDangerUtil.spawnFile(captureAny, captureAny))
           .thenAnswer((realInvocation) async {});
 
       when(_mockDangerUtil.getDangerFile(any))
@@ -58,21 +59,21 @@ void main() {
 
     test('Should pass dangerfile', () async {
       await _commandRunner
-          .run(['process', '--dangerfile', 'hello.dart', '--verbose']);
+          .run(['process', '--dangerfile', 'bin/danger_dart.dart', '--verbose']);
 
       final result =
-          verify(_mockDangerUtil.spawnUri(captureAny, captureAny)).captured;
+          verify(_mockDangerUtil.spawnFile(captureAny, captureAny)).captured;
       final url = result[0];
-      expect(url.toString(), endsWith('/hello.dart'));
+      expect(url.path.toString(), endsWith('/bin/danger_dart.dart'));
     });
 
     test('Should pass sendPort in message key DANGER_SEND_PORT_MESSAGE_KEY',
         () async {
       await _commandRunner
-          .run(['process', '--dangerfile', 'hello.dart', '--verbose']);
+          .run(['process', '--dangerfile', 'bin/danger_dart.dart', '--verbose']);
 
       final result =
-          verify(_mockDangerUtil.spawnUri(captureAny, captureAny)).captured;
+          verify(_mockDangerUtil.spawnFile(captureAny, captureAny)).captured;
       final message = result[1];
 
       final sendPort = message[DANGER_SEND_PORT_MESSAGE_KEY];
@@ -81,10 +82,10 @@ void main() {
 
     test('Should pass DSL in message key DANGER_DSL_MESSAGE_KEY', () async {
       await _commandRunner
-          .run(['process', '--dangerfile', 'hello.dart', '--verbose']);
+          .run(['process', '--dangerfile', 'bin/danger_dart.dart', '--verbose']);
 
       final result =
-          verify(_mockDangerUtil.spawnUri(captureAny, captureAny)).captured;
+          verify(_mockDangerUtil.spawnFile(captureAny, captureAny)).captured;
       final message = result[1];
 
       final dslJSON = message[DANGER_DSL_MESSAGE_KEY];
@@ -100,13 +101,14 @@ void main() {
 
     test('Should write and flush stdout after running dangerfile', () async {
       await _commandRunner
-          .run(['process', '--dangerfile', 'hello.dart', '--verbose']);
+          .run(['process', '--dangerfile', 'bin/danger_dart.dart', '--verbose']);
 
       verify(_mockStdout.flush()).called(1);
 
       final result = verify(_mockStdout.write(captureAny)).captured;
       final urlResult = result[0];
-      final fileResult = File(urlResult.toString().substring('danger-results:/'.length));
+      final fileResult =
+          File(urlResult.toString().substring('danger-results:/'.length));
       final str = fileResult.readAsStringSync();
       expect(
           str,

--- a/packages/danger_plugin_dart_test/README.md
+++ b/packages/danger_plugin_dart_test/README.md
@@ -29,9 +29,7 @@ import 'dart:io';
 import 'package:danger_core/danger_core.dart';
 import 'package:danger_plugin_dart_test/danger_plugin_dart_test.dart';
 
-void main(List<String> args, dynamic data) {
-  Danger.setup(data);
-
+void main() {
   final testResultFile = File('your_test_results.json');
   DangerPluginDartTest.processFile(testResultFile);
 }


### PR DESCRIPTION
We will create a new dangerfile next to existing dangerfile, so user don't have to implement `Danger.setUp`.

So, we can reduce boilerplate from
```dart
void main(List<String> args, dynamic data) {
  Danger.setup(data);
  message('Hello World');
}
```

to
```dart
void main() {
  message('Hello World');
}
```